### PR TITLE
add more information and advertisement in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/hyperium/hyper/master/LICENSE)
 [![Join the chat at https://gitter.im/yuchenhou/athanasea](https://badges.gitter.im/yuchenhou/athanasea.svg)](https://gitter.im/yuchenhou/athanasea?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Advanced virtual animal adoption web app (CAUTION: site under construction).
+Athanasea is a online game where players run their own rescue centers and rescue animals from sea. We're building it for children to play so that they can have fun and to learn about protecting aquatic animals. Many of us joined this project to learn and practice latest web technologies (e.g. MeteorJS, MongoDB), and it has been a very enjoyable experience. If you are interested in learning more about Athanasea or modern web app development, come in and talk to us in our Gitter chat room! We'd love to add you as a collaborator!


### PR DESCRIPTION
Today a stranger from github asked me to tell him more about our project. That reminded me that apparently we have more potential contributors in the open-source community who might be interested in contributing to Athanasea. This is a good reason for us to make a better readme in our home page to better advertise our project. It can also help us(and our future employers or co-founders) understand our own project better anyway. So I'm open this pull request to gather more ideas from you: what information do you think will be most valuable for a developer who wants to know about our exciting project? You can just comment on the README.md or push commits to this branch.
